### PR TITLE
Add Vitess to projects we contribute to

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -8,9 +8,9 @@ Listed within this GitHub org, you'll find a collection of things built by Slack
 
 &nbsp;
 
-In addition to publishing open source projects, Slack strives to actively participate in improving upon the core frameworks Slack is built upon, such as [Electron](https://github.com/electron/electron) and [Webpack](https://github.com/webpack/webpack).
+In addition to publishing open source projects, Slack strives to actively participate in improving upon the core frameworks and technologies Slack is built upon, such as [Electron](https://github.com/electron/electron), [Webpack](https://github.com/webpack/webpack) and [Vitess](https://github.com/vitessio/vitess).
 
-<a href="https://github.com/electron/electron"><img src="https://camo.githubusercontent.com/2ef2a441f9eaa1aca489796981cfa851d9388e08209b08e57526a06b4e604a57/68747470733a2f2f656c656374726f6e6a732e6f72672f696d616765732f656c656374726f6e2d6c6f676f2e737667" height="25"></a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://github.com/webpack/webpack"><img src="https://webpack.js.org/site-logo.1fcab817090e78435061.svg" height="25"></a>
+<a href="https://github.com/electron/electron"><img src="https://camo.githubusercontent.com/2ef2a441f9eaa1aca489796981cfa851d9388e08209b08e57526a06b4e604a57/68747470733a2f2f656c656374726f6e6a732e6f72672f696d616765732f656c656374726f6e2d6c6f676f2e737667" height="25"></a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://github.com/webpack/webpack"><img src="https://webpack.js.org/site-logo.1fcab817090e78435061.svg" height="25"></a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://github.com/vitessio/vitess"><img src="https://vitess.io/img/logos/vitess-horizontal.png" height="25"></a>
 
 
 In the words of our friends at [Salesforce](https://opensource.salesforce.com/):


### PR DESCRIPTION
Now that Slack's fork of Vitess is moved to [`slackhq/vitess`](https://github.com/slackhq/vitess) it probably makes sense to add it as a tech we contribute to [here](https://github.com/slackhq)

Vitess is not necessarily a "framework" so current wording was updated to:
> core frameworks and technologies Slack is built upon, such as Electon, Webpack and Vitess.

The Slack Datastores team contributes to our fork and the upstream Vitess project on a regular basis